### PR TITLE
Add link to ruby eventmachine in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EM-Kafka
 
-EventMachine driver for [Kafka](http://incubator.apache.org/kafka/index.html).
+[EventMachine](https://github.com/eventmachine/eventmachine) driver for [Kafka](http://incubator.apache.org/kafka/index.html).
 
 ## Producer
 


### PR DESCRIPTION
I think this will help disambiguate the term _EventMachine_. 

:smile_cat:
